### PR TITLE
Ensure puppet agent is stopped, if told so.

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -33,7 +33,7 @@ class puppet::common(
 	$tmp = sprintf("%s/", regsubst($::puppet::vardir::puppet_vardirtmp, '\/$', ''))
 
 	$ensure = $start ? {
-		false => undef,		# we don't want ensure => stopped
+		false => stopped,		# we want ensure => stopped
 		default => running,
 	}
 


### PR DESCRIPTION
If puppet RPM gets updated, RPM post-script will start puppet agent,
which might be an issue if we do something like this:

class { '::puppet::client':
    #start => true,
    start => false,         # useful for testing manually...
}

It's expected that client is stopped - but it won't happen. This patch
fixes it.
