### PR TITLE
Added RHEL-7.1 support to PuppetLabs yum repositories

### DIFF
--- a/manifests/params/repo/yum.pp
+++ b/manifests/params/repo/yum.pp
@@ -25,6 +25,7 @@ class puppet::params::repo::yum {
 		#6.4 => '6.4',
 		'6.5' => '6',
 		'7.0.1406' => '7',
+		'7.1' => '7'
 		default => "${operatingsystemrelease}",
 	}
 

--- a/manifests/params/repo/yum.pp
+++ b/manifests/params/repo/yum.pp
@@ -25,7 +25,7 @@ class puppet::params::repo::yum {
 		#6.4 => '6.4',
 		'6.5' => '6',
 		'7.0.1406' => '7',
-		'7.1' => '7'
+		'7.1' => '7',
 		default => "${operatingsystemrelease}",
 	}
 


### PR DESCRIPTION
Puppet Labs repo layout does not have
https://yum.puppetlabs.com/el/7.1/ directory - all RHEL7 packages are in
.../el/7/ instead.
This patch fixes this issue, and RHEL-7.1 Puppet provisioning works again.

Otherwise the generated repofile is wrong, and provisioning fails due to yum not working.
